### PR TITLE
add_text_index_page_and_detail_page_&_fix_order_error_of_questions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,7 +38,6 @@
     font-size: 20px;
 }
 
-
 /***
 markdown code 表示装飾　ここから
 ***/
@@ -104,6 +103,10 @@ markdown code 表示装飾　ここまで
   #container p {
     font-size: 2.2em;
     line-height: 1.9em;
+  }
+
+  #container tr {
+    font-size: 24px;
   }
 
   #questions .questions-container {
@@ -210,6 +213,11 @@ markdown code 表示装飾　ここまで
   }
 
   #container h1 {
+    padding: 20px 0px 10px 0px;
+    font-size: 30px;
+  }
+
+  #container h2 {
     padding: 20px 0px 10px 0px;
     font-size: 30px;
   }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,7 +1,7 @@
 class QuestionsController < ApplicationController
 
   def index
-    @questions = Question.all
+    @questions = Question.all.order(created_at: :desc)
     @question = Question.new
   end
 

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,0 +1,28 @@
+class TextsController < ApplicationController
+
+  def index
+    @texts = Text.all.order(number: :asc)
+  end
+
+  def show
+    @text = Text.find_by(id: params[:id])
+  end
+
+  def new
+    @text = Text.new
+  end
+
+  def create
+    @text = Text.new(text_params)
+    @text.save
+    flash[:success] = "テキスト教材を追加しました。"
+    redirect_to action: :index
+  end
+
+  private
+
+  def text_params
+    params.require(:text).permit(:number, :genre, :title, :content)
+  end
+
+end

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -1,6 +1,6 @@
 class Solution < ApplicationRecord
 
     validates :content, presence: true
-    
+
     belongs_to :question
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,0 +1,7 @@
+class Text < ApplicationRecord
+
+  validates :number, presence: true
+  validates :genre, presence: true
+  validates :title, presence: true
+  validates :content, presence: true
+end

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -30,7 +30,7 @@
                 </div>
                 <div class="col-md-5">
                   <div class="info text-right">
-                    <p>質問日　<%= l question.updated_at, format: :default %></p>
+                    <p>質問日　<%= l question.created_at, format: :default %></p>
                     <!--<p><%= question.views %>&nbsp;<%= question.views>=2 ? "views" : "view" %></p>-->
                     <p><%= pluralize(question.views, "view", locale: :en) %></p>
                   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <a class="dropdown-item" href="/">動画教材</a>
-          <a class="dropdown-item" href="#">テキスト教材</a>
+          <a class="dropdown-item" href="/texts">テキスト教材</a>
           <a class="dropdown-item" href="#">ライブコーディング</a>
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="/questions">質問集</a>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,0 +1,26 @@
+<div id="container">
+
+    <h2 class="text-center"><%= link_to "新規投稿（非オリジナル仕様）", new_text_path %></h2>
+
+    <h2 class="text-center">Railsテキスト教材</h2>
+
+    <table class="table table-striped">
+      <thead class="bg-danger text-white">
+        <tr>
+          <th class="text-nowrap">No.</th>
+          <th class="text-nowrap">ジャンル</th>
+          <th class="text-nowrap">内容</th>
+        </tr>
+      </thead>
+      <tbody id="myTable">
+        <% @texts.each do |text| %>
+          <tr>
+            <td><%= text.number %></td>
+            <td><%= text.genre %></td>
+            <td><%= link_to text.title, text_path(text) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+  </div>

--- a/app/views/texts/new.html.erb
+++ b/app/views/texts/new.html.erb
@@ -1,0 +1,15 @@
+<%= form_for @text do |f| %>
+    <div class="container">
+      <h3>番号（No.）</h3>
+      <p><%= f.number_field :number, class: "form-control initial-height" %></p>
+      <h3>ジャンル</h3>
+      <p><%= f.select :genre, [["Basic","Basic"], ["Ruby","Ruby"], ["Ruby on Rails","Ruby on Rails"]], :prompt => "選択してください", class: "form-control initial-height" %></p>
+      <h3>タイトル</h3>
+      <p><%= f.text_field :title, class: "form-control initial-height" %></p>
+      <h3>内容</h3>
+      <p><%= f.text_area :content, class: "form-control initial-height", rows: 5 %></p>
+      <div class="form-group">
+        <%= f.submit('送信',class: 'btn btn-primary btn-block btn-lg') %>
+      </div>
+    </div>
+<% end %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,5 @@
+<div id="container">
+
+    <%= markdown(@text.content).html_safe %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
 
   post "/solutions/:id" => "solutions#create"
 
+  resources :texts
+
 end

--- a/db/migrate/20200227203156_create_texts.rb
+++ b/db/migrate/20200227203156_create_texts.rb
@@ -1,0 +1,11 @@
+class CreateTexts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :texts do |t|
+      t.integer :number
+      t.string :genre
+      t.string :title
+      t.text :content
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_224305) do
+ActiveRecord::Schema.define(version: 2020_02_27_203156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,15 @@ ActiveRecord::Schema.define(version: 2020_02_24_224305) do
   create_table "solutions", force: :cascade do |t|
     t.text "content"
     t.integer "question_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "texts", force: :cascade do |t|
+    t.integer "number"
+    t.string "genre"
+    t.string "title"
+    t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,3 +22,13 @@ end
 
 Question.create!(title: "質問1", content: "ここに質問の詳細が表示される。")
 Question.create!(title: "質問2", content: "ここに質問の詳細が表示される。")
+
+# テキスト教材初期データ（仮）
+
+5.times do |no|
+  Text.create(number: no,
+              genre: "basic",
+              title: "タイトル#{no}",
+              content: "内容その#{no}",
+            )
+end


### PR DESCRIPTION
主要変更点
・テキスト教材ページ（index）追加
　　・seeds.rbにテキスト教材サンプルを記述
　　・テストのために新規投稿機能追加。非オリジナル仕様
・詳細ページ（show）追加
　　・マークダウン対応

修正点
・質問の並びが変わる問題。質問作成日の新しい順に上から並ぶよう設定